### PR TITLE
Tina

### DIFF
--- a/SpartaTraineeSimulator.iml
+++ b/SpartaTraineeSimulator.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_17">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_X">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/src/main/java/com/sparta/simulator/controller/SimulatorManager.java
+++ b/src/main/java/com/sparta/simulator/controller/SimulatorManager.java
@@ -1,9 +1,7 @@
 package com.sparta.simulator.controller;
 
-import com.sparta.simulator.model.TrainingCentre;
+import com.sparta.simulator.model.*;
 import com.sparta.simulator.start.display.Display;
-import com.sparta.simulator.model.Trainee;
-import com.sparta.simulator.model.TraineeFactory;
 
 import java.util.ArrayList;
 
@@ -15,12 +13,11 @@ public abstract class SimulatorManager {
 
         // we get the input from user to how long to run the simulation
         //      we assume the input is already checked, and will be a positive integer [ 1 - positive "infinite"]
-        int runtime = Display.mainDisplay();
+        int runtime = Display.scanSimulationLength();
+
+        int summaryChoice = Display.scanChoiceOfSummary();
 
 
-        // how many centres to generate each 2 month
-        // right now its a set value
-        // can be changed later to be based on user input
         int centresToGenerate = 1;
 
 
@@ -29,53 +26,28 @@ public abstract class SimulatorManager {
             System.out.printf("\n%d. month:\n", i);
 
             // Every 2 months, Sparta Global opens training centres; they open instantly and can take trainees every month.
-            // will handle the open instantly and can take trainees part when iterating through every centre together
             if (i%2 == 0) {
-                System.out.println("\t1 new centre have been created.");
-
-                TrainingCentre newCentre = new TrainingCentre();
-                centreList.add(newCentre);
+                openTrainingCentre(centreList);
             }
+
 
             // A centre can train a max of 100 trainees and takes a random number of trainees every month (0 - 50 trainees up to their capacity).
-            System.out.printf("\tcurrently we have %d centres:\n", centreList.size());
-            int totalFreeSpace = 0;
+            monthlyTraineeIntake(centreList);
 
-            int index = 1;
-            for(TrainingCentre centre: centreList) {
-                int prevCapacity = centre.getCurrentCapacity();
-                centre.startNewTraining();
-                int newCapacity = centre.getCurrentCapacity();
-                int newTrainingSize = newCapacity - prevCapacity;
-                int freeSpace = centre.getFreeSpace();
 
-                System.out.printf("\t\t%d. centre can take %d additional trainees this month. Now the centre's total capacity is %d, from which is %d free.\n", index, newTrainingSize, newCapacity, freeSpace);
-                totalFreeSpace += freeSpace;
-                index++;
-            }
+            // If all centres are full, the trainees go onto a waiting list; this list must be served first before new trainees are taken.
+            allocateFromWaitingList(waitingTrainees, centreList);
 
-            // if we have any trainee on the waiting list, we try to allocate them first
-            System.out.printf("\tcurrently %d trainee(s) on the waiting list.\n", waitingTrainees.size());
-            if (waitingTrainees.size() > 0) {
-                System.out.println("\t. . . allocating trainees . . .");
-                ArrayList<Trainee> newWaitingList = new ArrayList<>();
-                newWaitingList.addAll(allocateTrainees(waitingTrainees, centreList));
-                System.out.printf("\tafter allocating the waiting trainees among the free spaces, we have %d trainees on the waiting list.\n", waitingTrainees.size());
-            }
 
-            // call function to generate new Trainees wanting to be trained 50-100
-            ArrayList<Trainee> newTrainees = TraineeFactory.generateTrainees();
-            System.out.printf("\t%d new Trainees wanting to be trained this month.\n", newTrainees.size());
+            // Every month, a random number of trainees are generated, wanting to be trained (50 - 100).
+            monthlyNewTrainees(waitingTrainees, centreList);
 
-            // if we have a Trainee in the waiting list, this means all the spots are full -> just add the new Trainees at the end of the list
-            // if the waiting list is empty, we try to allocate the new trainees, and the leftover will be added to the waiting list
-            if (waitingTrainees.size() > 0) {
-                waitingTrainees.addAll(newTrainees);
-                System.out.printf("\tafter adding the new trainees to the waiting list, we have %d trainees on the waiting list.\n", waitingTrainees.size());
-            } else {
-                waitingTrainees.addAll(allocateTrainees(newTrainees, centreList));
-                System.out.printf("\tafter allocating the new trainees among the free spaces, we have %d trainees on the waiting list.\n", waitingTrainees.size());
-            }
+
+            // If a centre has fewer than 25 trainees, it will close.
+            // The trainees will be randomly moved to another suitable centre.
+            // Bootcamp: can remain open for 3 months if there are fewer than 25 trainees in attendance. If a Bootcamp has 3 consecutive months of low attendance, it will close
+
+            // mukodik eddig
 
             // call function from Display to print out that month's infos:
 //                number of open centres
@@ -89,6 +61,50 @@ public abstract class SimulatorManager {
     }
 
 
+    private static void openTrainingCentre(ArrayList<TrainingCentre> centres) {
+        int hubCount =  0;
+        int bootcampCount = 0;
+
+        for (TrainingCentre centre: centres) {
+            if (centre instanceof TrainingHub) {
+                hubCount++;
+            } else if (centre instanceof Bootcamp) {
+                bootcampCount++;
+            }
+        }
+
+        TrainingCentre newCentre = TrainingCentreFactory.generateTrainingCentre(bootcampCount, hubCount);
+
+        String centreType = String.valueOf(newCentre.getClass());
+        centreType = centreType.substring(centreType.lastIndexOf('.')+1);
+        System.out.printf("\t%S have been created.\n", centreType);
+
+        centres.add(newCentre);
+    }
+
+
+    private static void monthlyTraineeIntake(ArrayList<TrainingCentre> centres){
+        System.out.printf("\tcurrently we have %d open centres:\n", centres.size());
+        int totalFreeSpace = 0;
+
+        int index = 1;
+        for(TrainingCentre centre: centres) {
+            int prevCapacity = centre.getCurrentCapacity();
+            centre.startNewTraining();
+            int newCapacity = centre.getCurrentCapacity();
+            int newTrainingSize = newCapacity - prevCapacity;
+            int freeSpace = centre.getFreeSpace();
+
+            String centreType = String.valueOf(centre.getClass());
+            centreType = centreType.substring(centreType.lastIndexOf('.')+1);
+
+            System.out.printf("\t\t%d. %S can take %d additional trainees this month. Now the centre's total capacity is %d, from which is %d free.\n", index, centreType, newTrainingSize, newCapacity, freeSpace);
+            totalFreeSpace += freeSpace;
+            index++;
+        }
+    }
+
+
     private static ArrayList<Trainee> allocateTrainees(ArrayList<Trainee> traineesToAllocate, ArrayList<TrainingCentre> centreList) {
         // count how many total free spaces we have across the training centres
         int totalFreeSpace = 0;
@@ -96,12 +112,15 @@ public abstract class SimulatorManager {
             totalFreeSpace += centre.getFreeSpace();
         }
 
-        // if we have more trainees than actual places, we just fill up all the spots without thinking
-        // we iterate through the centres and add as many trainees as we can
+        // if all centres are full, we return the given list without wasting time on executing the rest of the code
         if (totalFreeSpace == 0) {
             return traineesToAllocate;
-        } else if (traineesToAllocate.size() >= totalFreeSpace){
-            for (TrainingCentre centre: centreList) {
+        }
+
+        // if we have more trainees than actual places, we just fill up all the spots without thinking
+        // we iterate through the centres and add as many trainees as we can
+        else if (traineesToAllocate.size() >= totalFreeSpace) {
+            for (TrainingCentre centre : centreList) {
                 if (centre.getFreeSpace() > 0) {
                     ArrayList<Trainee> leftoverTrainees = new ArrayList<>();
                     leftoverTrainees.addAll(centre.enrollTrainees(traineesToAllocate));
@@ -109,21 +128,25 @@ public abstract class SimulatorManager {
                     traineesToAllocate.addAll(leftoverTrainees);
                 }
             }
+        }
 
-        // we have more spaces than trainees to allocate
+        // if there are more spaces, than trainees to allocate
         // we iterate through the trainees, and insert them one by one to the next centre which still has space
-
-        } else {
+        else {
             int centreCount = centreList.size();
             int position = 0;
             boolean addedTrainee = false;
 
             // we will iterate through the trainees until there's no trainee left in the list
+            // possible infinite loop thanks to TechCentre restriction? -> count attempts which will tell if we tried every centre in the list
             while (traineesToAllocate.size() > 0) {
+                int attempts = 1;
+
                 do {
                     addedTrainee = centreList.get(position%centreCount).enrollTrainee(traineesToAllocate.get(0));
                     position++;
-                } while (addedTrainee);
+                    attempts++;
+                } while (addedTrainee && attempts < centreCount);
 
                 traineesToAllocate.remove(0);
             }
@@ -133,6 +156,42 @@ public abstract class SimulatorManager {
         return traineesToAllocate;
     }
 
-//    private static void
+
+    private static void allocateFromWaitingList(ArrayList<Trainee> waitingList, ArrayList<TrainingCentre> centreList){
+        System.out.printf("\tcurrently %d trainee(s) on the waiting list.\n", waitingList.size());
+
+        // if there are elements in the waiting list, then we proceed to allocate them, else move on
+        if (waitingList.size() > 0) {
+            System.out.println("\t. . . allocating trainees . . .");
+            allocateTrainees(waitingList, centreList);
+            System.out.printf("\tafter allocating the waiting trainees among the free spaces, we have %d trainees on the waiting list.\n", waitingList.size());
+        }
+
+    }
+
+
+    private static void monthlyNewTrainees(ArrayList<Trainee> waitingList, ArrayList<TrainingCentre> centreList){
+        ArrayList<Trainee> newTrainees = TraineeFactory.generateTrainees();
+        System.out.printf("\t%d new Trainees wanting to be trained this month.\n", newTrainees.size());
+
+        // if we have a Trainee in the waiting list, this means all the spots are full -> just add the new Trainees at the end of the list
+        // we will try to allocate the new trainees ONLY, in case the TechCentre has spot for trainees with matching Course type
+        // [we assume all the waiting trainees are in different course]
+
+//         maybe add a function to check if theres a Tech centre in the list??
+//         if no, not to run the allocate trainees for no vain
+        if (waitingList.size() > 0) {
+            allocateTrainees(newTrainees, centreList);
+
+            waitingList.addAll(newTrainees);
+            System.out.printf("\tafter allocating the new trainees among the course specific free spaces, we have %d trainees on the waiting list.\n", waitingList.size());
+        }
+
+        // if the waiting list is empty, we try to allocate the new trainees, and the leftover will be added to the waiting list
+        else {
+            waitingList.addAll(allocateTrainees(newTrainees, centreList));
+            System.out.printf("\tafter allocating the new trainees among the free spaces, we have %d trainees on the waiting list.\n", waitingList.size());
+        }
+    }
 
 }

--- a/src/main/java/com/sparta/simulator/model/Bootcamp.java
+++ b/src/main/java/com/sparta/simulator/model/Bootcamp.java
@@ -1,46 +1,101 @@
 package com.sparta.simulator.model;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 public class Bootcamp extends TrainingCentre {
-
     private final int MIN_CAPACITY = 25;
     private final int MAX_CAPACITY = 500;
-    private int lowCapacityTime = 0;
-    private int currentCapacity = 0;
-    private int onTheTraining = 0;
+    private int currentCapacity;
+    private ArrayList<Trainee> onTheTraining ;
+    private int lowAttendanceTime;
 
-    public int getLowCapacityTime() {
-        return lowCapacityTime;
-    }
-
-    public void lowCapacityTime(int lowCapacityTime) {
-        this.lowCapacityTime++;
-    }
 
     public Bootcamp() {
         this.currentCapacity = 0;
-        startNewTraining();
-        this.onTheTraining = 0;
+        this.onTheTraining = new ArrayList<>();
+        this.lowAttendanceTime = 0;
+    }
+
+
+    public int getMAX_CAPACITY() {
+        return MAX_CAPACITY;
     }
 
     @Override
-    public int enrolledTraining(int num) {
-        int leftTrainees = 0;
-        int freeSpaces = this.currentCapacity - this.onTheTraining;
-        if(freeSpaces >= num) {
-            this.onTheTraining += num;
+    public int getCurrentCapacity() {
+        return currentCapacity;
+    }
+
+    @Override
+    public void setCurrentCapacity(int currentCapacity) {
+        this.currentCapacity = currentCapacity;
+    }
+
+    @Override
+    public ArrayList<Trainee> getOnTheTraining() {
+        return onTheTraining;
+    }
+
+    @Override
+    public void setOnTheTraining(ArrayList<Trainee> onTheTraining) {
+        this.onTheTraining = onTheTraining;
+    }
+
+    public void setLowAttendanceTime(int lowAttendanceTime) {
+        this.lowAttendanceTime = lowAttendanceTime;
+    }
+
+    public int getLowAttendanceTime() {
+        return lowAttendanceTime;
+    }
+
+    public void incrementLowAttendanceTime() {
+        this.lowAttendanceTime++;
+    }
+
+
+    // to reset the lowAttendanceTime, whenever new trainee added and the attendance reached 25!
+    @Override
+    public ArrayList<Trainee> enrollTrainees(ArrayList<Trainee> trainees) {
+        ArrayList<Trainee> leftoverTrainees = new ArrayList<>();
+        int freeSpaces = this.getFreeSpace();
+
+        if(freeSpaces >= trainees.size()) {
+            this.onTheTraining.addAll(trainees);
         } else {
-            leftTrainees = num - freeSpaces;
-            this.onTheTraining += freeSpaces;
+            for (int i=0 ; i<freeSpaces ; i++) {
+                this.onTheTraining.add(trainees.get(0));
+                trainees.remove(0);
+            }
+
+            leftoverTrainees.addAll(trainees);
         }
-        return leftTrainees;
+
+        resetLowAttendanceTime();
+
+        return leftoverTrainees;
     }
 
     @Override
-    public void startNewTraining() {
+    public boolean enrollTrainee(Trainee trainee) {
+        boolean successful = false;
+
+        if (this.getFreeSpace() > 0) {
+            this.onTheTraining.add(trainee);
+            successful = true;
+        }
+
+        resetLowAttendanceTime();
+
+        return successful;
+    }
+
+
+    @Override
+    public void startNewTraining(){
         Random rand = new Random();
-        int max = MAX_CAPACITY - this.currentCapacity;
+        int max = this.MAX_CAPACITY - this.currentCapacity;
         int places;
         if(max >= 50) {
             places = rand.nextInt(0,51);
@@ -48,6 +103,19 @@ public class Bootcamp extends TrainingCentre {
             places = rand.nextInt(0, max+1);
         }
         this.currentCapacity += places;
+    }
+
+
+    @Override
+    public int getFreeSpace() {
+        return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
+
+
+    private void resetLowAttendanceTime() {
+        if (this.onTheTraining.size() >= 25) {
+            this.lowAttendanceTime = 0;
+        }
     }
 
 }

--- a/src/main/java/com/sparta/simulator/model/Bootcamp.java
+++ b/src/main/java/com/sparta/simulator/model/Bootcamp.java
@@ -51,7 +51,9 @@ public class Bootcamp extends TrainingCentre {
     }
 
     public void incrementLowAttendanceTime() {
-        this.lowAttendanceTime++;
+        if (this.onTheTraining.size() < 25) {
+            this.lowAttendanceTime++;
+        }
     }
 
 
@@ -91,7 +93,6 @@ public class Bootcamp extends TrainingCentre {
         return successful;
     }
 
-
     @Override
     public void startNewTraining(){
         Random rand = new Random();
@@ -103,19 +104,24 @@ public class Bootcamp extends TrainingCentre {
             places = rand.nextInt(0, max+1);
         }
         this.currentCapacity += places;
-    }
 
+        incrementLowAttendanceTime();
+    }
 
     @Override
     public int getFreeSpace() {
         return this.getCurrentCapacity() - this.getOnTheTraining().size();
     }
 
-
     private void resetLowAttendanceTime() {
         if (this.onTheTraining.size() >= 25) {
             this.lowAttendanceTime = 0;
         }
+    }
+
+    @Override
+    public boolean remainOpen() {
+        return (onTheTraining.size() >= 25 || lowAttendanceTime < 3);
     }
 
 }

--- a/src/main/java/com/sparta/simulator/model/TechCentre.java
+++ b/src/main/java/com/sparta/simulator/model/TechCentre.java
@@ -1,44 +1,88 @@
 package com.sparta.simulator.model;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 public class TechCentre extends TrainingCentre {
-
     private final int MIN_CAPACITY = 25;
     private final int MAX_CAPACITY = 200;
-
-    public Course getCourse() { return course; }
-
-    private Course course;
     private int currentCapacity = 0;
-    private int onTheTraining = 0;
+    private ArrayList<Trainee> onTheTraining = new ArrayList<>();
+    private Course course;
 
 
     public TechCentre() {
         this.currentCapacity = 0;
-        startNewTraining();
-        this.onTheTraining = 0;
+        this.onTheTraining = new ArrayList<Trainee>();
+
         Random random = new Random();
         this.course = Course.values()[random.nextInt(0, Course.values().length)];
     }
 
+
+    public int getMAX_CAPACITY() {
+        return MAX_CAPACITY;
+    }
+
+    public Course getCourse() { return course; }
+
     @Override
-    public int enrolledTraining(int num) {
-        int leftTrainees = 0;
-        int freeSpaces = this.currentCapacity - this.onTheTraining;
-        if(freeSpaces >= num) {
-            this.onTheTraining += num;
-        } else {
-            leftTrainees = num - freeSpaces;
-            this.onTheTraining += freeSpaces;
-        }
-        return leftTrainees;
+    public int getCurrentCapacity() {
+        return currentCapacity;
     }
 
     @Override
-    public void startNewTraining() {
+    public void setCurrentCapacity(int currentCapacity) {
+        this.currentCapacity = currentCapacity;
+    }
+
+    @Override
+    public ArrayList<Trainee> getOnTheTraining() {
+        return onTheTraining;
+    }
+
+    @Override
+    public void setOnTheTraining(ArrayList<Trainee> onTheTraining) {
+        this.onTheTraining = onTheTraining;
+    }
+
+    // to check the Trainee course matches the Hub type before trying to enroll to the Trainee
+    @Override
+    public ArrayList<Trainee> enrollTrainees(ArrayList<Trainee> trainees) {
+        ArrayList<Trainee> leftoverTrainees = new ArrayList<>();
+        int freeSpaces = this.getFreeSpace();
+
+        for (Trainee trainee: trainees) {
+            if (freeSpaces == 0) {
+                leftoverTrainees.add(trainee);
+            } else if (enrollTrainee(trainee)) {
+                freeSpaces--;
+            } else {
+                leftoverTrainees.add(trainee);
+            }
+        }
+
+        return leftoverTrainees;
+    }
+
+
+    @Override
+    public boolean enrollTrainee(Trainee trainee) {
+        boolean successful = false;
+
+        if ( this.getFreeSpace() > 0 && isCourseMatch(trainee) ) {
+            this.onTheTraining.add(trainee);
+            successful = true;
+        }
+
+        return successful;
+    }
+
+
+    @Override
+    public void startNewTraining(){
         Random rand = new Random();
-        int max = MAX_CAPACITY - this.currentCapacity;
+        int max = this.MAX_CAPACITY - this.currentCapacity;
         int places;
         if(max >= 50) {
             places = rand.nextInt(0,51);
@@ -49,6 +93,13 @@ public class TechCentre extends TrainingCentre {
     }
 
 
+    public boolean isCourseMatch(Trainee trainee) {
+        return (trainee.getCourseType() == this.course);
+    }
 
+    @Override
+    public int getFreeSpace() {
+        return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
 
 }

--- a/src/main/java/com/sparta/simulator/model/TechCentre.java
+++ b/src/main/java/com/sparta/simulator/model/TechCentre.java
@@ -46,6 +46,7 @@ public class TechCentre extends TrainingCentre {
         this.onTheTraining = onTheTraining;
     }
 
+
     // to check the Trainee course matches the Hub type before trying to enroll to the Trainee
     @Override
     public ArrayList<Trainee> enrollTrainees(ArrayList<Trainee> trainees) {
@@ -65,7 +66,6 @@ public class TechCentre extends TrainingCentre {
         return leftoverTrainees;
     }
 
-
     @Override
     public boolean enrollTrainee(Trainee trainee) {
         boolean successful = false;
@@ -78,7 +78,6 @@ public class TechCentre extends TrainingCentre {
         return successful;
     }
 
-
     @Override
     public void startNewTraining(){
         Random rand = new Random();
@@ -89,9 +88,9 @@ public class TechCentre extends TrainingCentre {
         } else {
             places = rand.nextInt(0, max+1);
         }
+
         this.currentCapacity += places;
     }
-
 
     public boolean isCourseMatch(Trainee trainee) {
         return (trainee.getCourseType() == this.course);
@@ -100,6 +99,11 @@ public class TechCentre extends TrainingCentre {
     @Override
     public int getFreeSpace() {
         return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
+
+    @Override
+    public boolean remainOpen() {
+        return (this.onTheTraining.size() >= 25);
     }
 
 }

--- a/src/main/java/com/sparta/simulator/model/Trainee.java
+++ b/src/main/java/com/sparta/simulator/model/Trainee.java
@@ -11,4 +11,8 @@ public class Trainee {
         Random random = new Random();
         this.courseType = Course.values()[random.nextInt(0, Course.values().length)];
     }
+
+    public Course getCourseType() {
+        return courseType;
+    }
 }

--- a/src/main/java/com/sparta/simulator/model/TrainingCentre.java
+++ b/src/main/java/com/sparta/simulator/model/TrainingCentre.java
@@ -3,10 +3,12 @@ package com.sparta.simulator.model;
 import java.util.ArrayList;
 import java.util.Random;
 
-public abstract class TrainingCentre {
+public class TrainingCentre {
     private final int MIN_CAPACITY = 25;
+    private final int MAX_CAPACITY = 100;
     private int currentCapacity = 0;
-    private int onTheTraining = 0;
+    private ArrayList<Trainee> onTheTraining = new ArrayList<>();
+
 
     public int getMIN_CAPACITY() { return MIN_CAPACITY; }
 
@@ -17,14 +19,54 @@ public abstract class TrainingCentre {
         this.currentCapacity = currentCapacity;
     }
 
-    public int getOnTheTraining() { return onTheTraining; }
-    public void setOnTheTraining(int onTheTraining) {
+    public ArrayList<Trainee> getOnTheTraining() { return onTheTraining; }
+    public void setOnTheTraining(ArrayList<Trainee> onTheTraining) {
         this.onTheTraining = onTheTraining;
     }
 
 
-    // number of trainees left
-    public abstract int enrolledTraining(int num);
+    public ArrayList<Trainee> enrollTrainees(ArrayList<Trainee> trainees) {
+        ArrayList<Trainee> leftoverTrainees = new ArrayList<>();
+        int freeSpaces = this.getFreeSpace();
 
-    public abstract void startNewTraining();
+        if(freeSpaces >= trainees.size()) {
+            this.onTheTraining.addAll(trainees);
+        } else {
+            for (int i=0 ; i<freeSpaces ; i++) {
+                this.onTheTraining.add(trainees.get(0));
+                trainees.remove(0);
+            }
+
+            leftoverTrainees.addAll(trainees);
+        }
+        return leftoverTrainees;
+    }
+
+    public boolean enrollTrainee(Trainee trainee) {
+        boolean successful = false;
+
+        if (this.getFreeSpace() > 0) {
+            this.onTheTraining.add(trainee);
+            successful = true;
+        }
+
+        return successful;
+    }
+
+    public void startNewTraining(){
+        Random rand = new Random();
+        int max = MAX_CAPACITY - this.currentCapacity;
+        int places;
+        if(max >= 50) {
+            places = rand.nextInt(0,51);
+        } else {
+            places = rand.nextInt(0, max+1);
+        }
+        this.currentCapacity += places;
+    }
+
+
+    public int getFreeSpace() {
+        return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
 }

--- a/src/main/java/com/sparta/simulator/model/TrainingCentre.java
+++ b/src/main/java/com/sparta/simulator/model/TrainingCentre.java
@@ -65,8 +65,11 @@ public class TrainingCentre {
         this.currentCapacity += places;
     }
 
-
     public int getFreeSpace() {
         return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
+
+    public boolean remainOpen() {
+        return (onTheTraining.size() >= 25);
     }
 }

--- a/src/main/java/com/sparta/simulator/model/TrainingHub.java
+++ b/src/main/java/com/sparta/simulator/model/TrainingHub.java
@@ -1,38 +1,81 @@
 package com.sparta.simulator.model;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 public class TrainingHub extends TrainingCentre {
-
     private final int MIN_CAPACITY = 25;
     private final int MAX_CAPACITY = 100;
-    private int currentCapacity = 0;
-    private int onTheTraining = 0;
+    private int currentCapacity;
+    private ArrayList<Trainee> onTheTraining;
 
 
     public TrainingHub() {
         this.currentCapacity = 0;
-        startNewTraining();
-        this.onTheTraining = 0;
+        this.onTheTraining = new ArrayList<>();
+    }
+
+
+    public int getMAX_CAPACITY() {
+        return MAX_CAPACITY;
     }
 
     @Override
-    public int enrolledTraining(int num) {
-        int leftTrainees = 0;
-        int freeSpaces = this.currentCapacity - this.onTheTraining;
-        if(freeSpaces >= num) {
-            this.onTheTraining += num;
+    public int getCurrentCapacity() {
+        return currentCapacity;
+    }
+
+    @Override
+    public void setCurrentCapacity(int currentCapacity) {
+        this.currentCapacity = currentCapacity;
+    }
+
+    @Override
+    public ArrayList<Trainee> getOnTheTraining() {
+        return onTheTraining;
+    }
+
+    @Override
+    public void setOnTheTraining(ArrayList<Trainee> onTheTraining) {
+        this.onTheTraining = onTheTraining;
+    }
+
+    @Override
+    public ArrayList<Trainee> enrollTrainees(ArrayList<Trainee> trainees) {
+        ArrayList<Trainee> leftoverTrainees = new ArrayList<>();
+        int freeSpaces = this.getFreeSpace();
+
+        if(freeSpaces >= trainees.size()) {
+            this.onTheTraining.addAll(trainees);
         } else {
-            leftTrainees = num - freeSpaces;
-            this.onTheTraining += freeSpaces;
+            for (int i=0 ; i<freeSpaces ; i++) {
+                this.onTheTraining.add(trainees.get(0));
+                trainees.remove(0);
+            }
+
+            leftoverTrainees.addAll(trainees);
         }
-        return leftTrainees;
+        return leftoverTrainees;
     }
 
+
     @Override
-    public void startNewTraining() {
+    public boolean enrollTrainee(Trainee trainee) {
+        boolean successful = false;
+
+        if (this.getFreeSpace() > 0) {
+            this.onTheTraining.add(trainee);
+            successful = true;
+        }
+
+        return successful;
+    }
+
+
+    @Override
+    public void startNewTraining(){
         Random rand = new Random();
-        int max = MAX_CAPACITY - this.currentCapacity;
+        int max = this.MAX_CAPACITY - this.currentCapacity;
         int places;
         if(max >= 50) {
             places = rand.nextInt(0,51);
@@ -43,5 +86,9 @@ public class TrainingHub extends TrainingCentre {
     }
 
 
+    @Override
+    public int getFreeSpace() {
+        return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
 }
 

--- a/src/main/java/com/sparta/simulator/model/TrainingHub.java
+++ b/src/main/java/com/sparta/simulator/model/TrainingHub.java
@@ -40,6 +40,7 @@ public class TrainingHub extends TrainingCentre {
         this.onTheTraining = onTheTraining;
     }
 
+
     @Override
     public ArrayList<Trainee> enrollTrainees(ArrayList<Trainee> trainees) {
         ArrayList<Trainee> leftoverTrainees = new ArrayList<>();
@@ -58,7 +59,6 @@ public class TrainingHub extends TrainingCentre {
         return leftoverTrainees;
     }
 
-
     @Override
     public boolean enrollTrainee(Trainee trainee) {
         boolean successful = false;
@@ -70,7 +70,6 @@ public class TrainingHub extends TrainingCentre {
 
         return successful;
     }
-
 
     @Override
     public void startNewTraining(){
@@ -85,10 +84,14 @@ public class TrainingHub extends TrainingCentre {
         this.currentCapacity += places;
     }
 
-
     @Override
     public int getFreeSpace() {
         return this.getCurrentCapacity() - this.getOnTheTraining().size();
+    }
+
+    @Override
+    public boolean remainOpen() {
+        return (onTheTraining.size() >= 25);
     }
 }
 

--- a/src/main/java/com/sparta/simulator/start/Main.java
+++ b/src/main/java/com/sparta/simulator/start/Main.java
@@ -2,6 +2,7 @@ package com.sparta.simulator.start;
 
 import com.sparta.simulator.controller.SimulatorManager;
 import com.sparta.simulator.model.TechCentre;
+import com.sparta.simulator.model.Trainee;
 import com.sparta.simulator.model.TrainingCentre;
 import com.sparta.simulator.model.TrainingCentreFactory;
 
@@ -10,5 +11,6 @@ import java.util.ArrayList;
 public class Main {
     public static void main(String[] args) {
         SimulatorManager.initialise();
+
     }
 }

--- a/src/main/java/com/sparta/simulator/start/display/Display.java
+++ b/src/main/java/com/sparta/simulator/start/display/Display.java
@@ -1,25 +1,101 @@
 package com.sparta.simulator.start.display;
 
+import com.sparta.simulator.model.Trainee;
+import com.sparta.simulator.model.TrainingCentre;
+
+import java.util.ArrayList;
+import java.util.InputMismatchException;
 import java.util.Scanner;
 
 public abstract class Display {
 
-    public static int mainDisplay() {
-        Scanner input = new Scanner(System.in);
-        int noFullCentres, noOpenCentres, noInTraining, noInWaitingList;
-        noFullCentres = noOpenCentres = noInTraining = noInWaitingList = 0;
+    public static void summaryDisplay(ArrayList<TrainingCentre> openCentres, ArrayList<TrainingCentre> closedCentres, ArrayList<Trainee> waitingList) {
+        System.out.println("\n\nSUMMARY AT THE END OF SIMULATION\n");
 
-        System.out.println("Enter the number of months to run the simulation for: ");
+//        StringBuilder sb = new StringBuilder("Number of open training centres:\n");
+        int openHub, openBootcamp, openTech;
+        int closedHub, closedBootcamp, closedTech;
+        int fullHub, fullBootcamp, fullTech;
 
-        int length = input.nextInt();
+        fullHub = fullBootcamp = fullTech = closedHub = closedBootcamp = closedTech = openHub = openBootcamp = openTech = 0;
+        for (TrainingCentre open: openCentres) {
+            openHub++;
+            // code to add to corresponding centre type
 
-        // run code
+//            if (open.getFreeSpace() == 0) {
+//                fullHub++;
+//            }
+        }
 
-        System.out.println("Number of full training centres: " + noFullCentres);
-        System.out.println("Number of open training centres: " + noOpenCentres);
-        System.out.println("Number of trainees in training: " + noInTraining);
-        System.out.println("Number of trainees in waiting list: " + noInWaitingList);
+        for (TrainingCentre close: closedCentres) {
+            closedHub++;
+        }
 
-        return length;
+
+
+        System.out.println("Number of closed training centres: " );
+        System.out.println("Number of full training centres: " );
+
+        //Java, C#, Data, DevOps or Business
+        int java, cSharp, data, devOps, business =0;
+
+        System.out.println("Number of trainees in training: " );
+        System.out.println("Number of trainees in waiting list: " );
+
+    }
+
+    public static int scanSimulationLength() {
+        boolean suitableInput = false;
+        int simulationLength = -1;
+        System.out.println("\nSetting the simulation length...");
+
+        while ( !suitableInput ) {
+            try {
+                Scanner scan = new Scanner(System.in);
+
+                do {
+                    System.out.println("Please enter a positive number, which represents the months:");
+
+                    simulationLength = scan.nextInt();
+
+                } while (simulationLength < 1);
+
+                suitableInput = true;
+
+            } catch (InputMismatchException e) {
+//                e.printStackTrace();
+                System.out.print("The input is not a number!! ");
+            }
+        }
+
+        return simulationLength;
+    }
+
+    public static int scanChoiceOfSummary() {
+        boolean suitableInput = false;
+        int summaryChoice = 0;
+
+        System.out.println("\nPlease select the type of output option:\n\t1. Summary data at the end of the simulation\n\t2. Running output updated each month.");
+
+        while ( !suitableInput ) {
+            try {
+                Scanner scan = new Scanner(System.in);
+
+                do {
+                    System.out.println("Please enter the corresponding number");
+                    summaryChoice = scan.nextInt();
+
+                } while ( !(summaryChoice == 1 || summaryChoice == 2) );
+
+                suitableInput = true;
+
+            } catch (InputMismatchException e) {
+//                e.printStackTrace();
+                // maybe log the user gave incorrect input, starting the loop again
+                System.out.print("The input is not a number!! ");
+            }
+        }
+
+        return summaryChoice;
     }
 }


### PR DESCRIPTION
updated SimulatorManager and tweaked TrainingCentres

TrainingHub will now check course matches before attempting to add a Trainee
Instead of showing the new trainees to the end of the list, will try to allocate them first (possible free spaces in TrainingHub due to course restriction)
Updated display to accept only valid input from user
added choice of data summary to the Display, but it do not influence the outcome yet
SimulatorManager, so now it will shut down centres & attempt to allocate trainees before putting them to the beginning of waiting list.